### PR TITLE
Admin analytics dashboard + preparación Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Build web for GitHub Pages
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/
+          VITE_ANALYTICS_API_ORIGIN: ""
         run: npm run build --workspace web
 
       - name: Upload Pages artifact

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,6 +43,7 @@ jobs:
           path: apps/web/dist
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/apps/api/dist/server.js
+++ b/apps/api/dist/server.js
@@ -304,6 +304,9 @@ function adminHtml() {
 await server.register(cors, {
     origin: true,
 });
+server.get('/', async (request, reply) => {
+    return reply.redirect('/admin');
+});
 server.get('/health', async () => {
     return {
         name: 'codebreaker-api',

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,6 +11,57 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      (function () {
+        const storageKey = 'codebreaker_visitor_id';
+        let visitorId = null;
+
+        try {
+          visitorId = window.localStorage.getItem(storageKey);
+          if (!visitorId) {
+            if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+              visitorId = window.crypto.randomUUID();
+            } else {
+              visitorId = 'v-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+            }
+            window.localStorage.setItem(storageKey, visitorId);
+          }
+        } catch (_error) {
+          visitorId = null;
+        }
+
+        const configuredOrigin = '%VITE_ANALYTICS_API_ORIGIN%';
+        const hasConfiguredOrigin = configuredOrigin && !configuredOrigin.startsWith('%VITE_');
+        const explicitEndpoint = hasConfiguredOrigin
+          ? configuredOrigin.replace(/\/$/, '') + '/api/analytics/visit'
+          : null;
+
+        const payload = {
+          visitorId,
+          page: window.location.pathname + window.location.search,
+          source: 'web',
+        };
+
+        const candidates = [];
+        if (explicitEndpoint) candidates.push(explicitEndpoint);
+        candidates.push('/api/analytics/visit');
+
+        function sendVisit(index) {
+          if (index >= candidates.length) return;
+
+          fetch(candidates[index], {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+            keepalive: true,
+          }).catch(function () {
+            sendVisit(index + 1);
+          });
+        }
+
+        sendVisit(0);
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
   </html>

--- a/proyecto/.github/workflows/deploy-pages.yml
+++ b/proyecto/.github/workflows/deploy-pages.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Build web for GitHub Pages
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/
+          VITE_ANALYTICS_API_ORIGIN: ""
         run: npm run build --workspace web
 
       - name: Upload Pages artifact

--- a/proyecto/.github/workflows/deploy-pages.yml
+++ b/proyecto/.github/workflows/deploy-pages.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,6 +43,7 @@ jobs:
           path: apps/web/dist
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/proyecto/apps/web/index.html
+++ b/proyecto/apps/web/index.html
@@ -11,6 +11,57 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      (function () {
+        const storageKey = 'codebreaker_visitor_id';
+        let visitorId = null;
+
+        try {
+          visitorId = window.localStorage.getItem(storageKey);
+          if (!visitorId) {
+            if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+              visitorId = window.crypto.randomUUID();
+            } else {
+              visitorId = 'v-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+            }
+            window.localStorage.setItem(storageKey, visitorId);
+          }
+        } catch (_error) {
+          visitorId = null;
+        }
+
+        const configuredOrigin = '%VITE_ANALYTICS_API_ORIGIN%';
+        const hasConfiguredOrigin = configuredOrigin && !configuredOrigin.startsWith('%VITE_');
+        const explicitEndpoint = hasConfiguredOrigin
+          ? configuredOrigin.replace(/\/$/, '') + '/api/analytics/visit'
+          : null;
+
+        const payload = {
+          visitorId,
+          page: window.location.pathname + window.location.search,
+          source: 'web',
+        };
+
+        const candidates = [];
+        if (explicitEndpoint) candidates.push(explicitEndpoint);
+        candidates.push('/api/analytics/visit');
+
+        function sendVisit(index) {
+          if (index >= candidates.length) return;
+
+          fetch(candidates[index], {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+            keepalive: true,
+          }).catch(function () {
+            sendVisit(index + 1);
+          });
+        }
+
+        sendVisit(0);
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
   </html>


### PR DESCRIPTION
## Resumen\n- Agrega tracking de visitas en frontend para analytics\n- Ajusta workflow de Pages para que despliegue solo desde main\n- Deja configuración lista para evitar rechazo por environment protection\n\n## Nota\nEl deploy de GitHub Pages se ejecutará al mergear este PR a main.