### PR TITLE
Fix Pages analytics endpoint

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build web for GitHub Pages
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/
-          VITE_ANALYTICS_API_ORIGIN: ""
+          VITE_ANALYTICS_API_ORIGIN: https://fantastic-journey-4p94w7v6p9p3jjp5-4000.app.github.dev
         run: npm run build --workspace web
 
       - name: Upload Pages artifact

--- a/proyecto/.github/workflows/deploy-pages.yml
+++ b/proyecto/.github/workflows/deploy-pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build web for GitHub Pages
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/
-          VITE_ANALYTICS_API_ORIGIN: ""
+          VITE_ANALYTICS_API_ORIGIN: https://fantastic-journey-4p94w7v6p9p3jjp5-4000.app.github.dev
         run: npm run build --workspace web
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Fix\nConfigura VITE_ANALYTICS_API_ORIGIN en el workflow de Pages para que el frontend publicado registre visitas contra la API pública.\n\n## Nota\nRequiere que el puerto 4000 del Codespace se mantenga público y activo.